### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This project implements a Model Context Protocol (MCP) server that exposes Google's Veo2 video generation capabilities. It allows clients to generate videos from text prompts or images, and access the generated videos through MCP resources.
 
+<a href="https://glama.ai/mcp/servers/@mario-andreschak/mcp-veo2">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mario-andreschak/mcp-veo2/badge" alt="Video Generation with Veo2 MCP server" />
+</a>
+
 ## Features
 
 - Generate **videos from text** prompts


### PR DESCRIPTION
This PR adds a badge for the [MCP Video Generation with Veo2](https://glama.ai/mcp/servers/@mario-andreschak/mcp-veo2) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@mario-andreschak/mcp-veo2">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@mario-andreschak/mcp-veo2/badge" alt="Video Generation with Veo2 MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.